### PR TITLE
add jewish holidays: purim, shavuot & sukkot

### DIFF
--- a/convertdate/holidays.py
+++ b/convertdate/holidays.py
@@ -210,6 +210,16 @@ def hanukkah(year, eve=None):
     return year, month, day
 
 
+def purim(year, eve=None):
+    if not hebrew.leap(year + hebrew.HEBREW_YEAR_OFFSET):
+        year, month, day = hebrew.to_jd_gregorianyear(year, hebrew.ADAR, 14)
+    else:
+        year, month, day = hebrew.to_jd_gregorianyear(year, hebrew.VEADAR, 14)  
+    if eve:
+        day = day - 1
+    return year, month, day
+
+
 def rosh_hashanah(year, eve=None):
     year, month, day = hebrew.to_jd_gregorianyear(year, hebrew.TISHRI, 1)
     if eve:
@@ -221,7 +231,6 @@ def yom_kippur(year, eve=None):
     year, month, day = hebrew.to_jd_gregorianyear(year, hebrew.TISHRI, 10)
     if eve:
         day = day - 1
-
     return year, month, day
 
 
@@ -229,8 +238,22 @@ def passover(year, eve=None):
     year, month, day = hebrew.to_jd_gregorianyear(year, hebrew.NISAN, 15)
     if eve:
         day = day - 1
-
     return year, month, day
+
+
+def shavuot(year, eve=None):
+    year, month, day = hebrew.to_jd_gregorianyear(year, hebrew.SIVAN, 6)
+    if eve:
+        day = day - 1
+    return year, month, day
+
+
+def sukkot(year, eve=None):
+    year, month, day = hebrew.to_jd_gregorianyear(year, hebrew.TISHRI, 15)
+    if eve:
+        day = day - 1
+    return year, month, day
+
 
 # Mexican holidays
 
@@ -362,6 +385,10 @@ class Holidays(object):
         return hanukkah(self.year, eve=False)
 
     @property
+    def purim(self):
+        return purim(self.year, eve=False)
+
+    @property
     def rosh_hashanah(self):
         return rosh_hashanah(self.year, eve=False)
 
@@ -372,6 +399,14 @@ class Holidays(object):
     @property
     def passover(self):
         return passover(self.year, eve=False)
+
+    @property
+    def shavuot(self):
+        return shavuot(self.year, eve=False)
+
+    @property
+    def sukkot(self):
+        return sukkot(self.year, eve=False)
 
     @property
     def dia_constitucion(self):

--- a/tests/test_holidays.py
+++ b/tests/test_holidays.py
@@ -149,6 +149,27 @@ class TestHolidays(unittest.TestCase):
         self.assertEqual(holidays.yom_kippur(2015), (2015, 9, 23))
         self.assertEqual(holidays.yom_kippur(2015, True), (2015, 9, 22))
 
+        sukkots = [
+            (2016, 10, 17),
+            (2015, 9, 28),
+        ]
+        for y, m, d in sukkots:
+            self.assertEqual(holidays.sukkot(y, eve=0), (y, m, d))
+
+        shavuots = [
+            (2016, 6, 12),
+            (2015, 5, 24)
+        ]
+        for y, m, d in shavuots:
+            self.assertEqual(holidays.shavuot(y, eve=0), (y, m, d))
+
+        purims = [
+            (2017, 3, 12),
+            (2016, 3, 24)
+        ]
+        for y, m, d in purims:
+            self.assertEqual(holidays.purim(y, eve=0), (y, m, d))
+
         assert self.h.hanukkah == (2015, 12, 7)
         assert self.h.rosh_hashanah == (2015, 9, 14)
         assert self.h.yom_kippur == (2015, 9, 23)


### PR DESCRIPTION
[Purim](https://en.wikipedia.org/wiki/Purim) importance is equivalent to Hanukka, while [Shavuot](https://en.wikipedia.org/wiki/Shavuot) & [Sukkot](https://en.wikipedia.org/wiki/Sukkot) importance is equivalent to Pesach.

Tests dates taken from [google jewish holiday calendar](https://calendar.google.com/calendar/embed?src=jewish@holiday.calendar.google.com).