### PR TITLE
Remove shebang

### DIFF
--- a/convertdate/__init__.py
+++ b/convertdate/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # This file is part of convertdate.

--- a/convertdate/bahai.py
+++ b/convertdate/bahai.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # This file is part of convertdate.

--- a/convertdate/coptic.py
+++ b/convertdate/coptic.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # This file is part of convertdate.

--- a/convertdate/data/french_republican_days.py
+++ b/convertdate/data/french_republican_days.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # This file is part of convertdate.

--- a/convertdate/data/positivist.py
+++ b/convertdate/data/positivist.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 day_names = (

--- a/convertdate/daycount.py
+++ b/convertdate/daycount.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # This file is part of convertdate.

--- a/convertdate/dublin.py
+++ b/convertdate/dublin.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # This file is part of convertdate.

--- a/convertdate/french_republican.py
+++ b/convertdate/french_republican.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # This file is part of convertdate.

--- a/convertdate/gregorian.py
+++ b/convertdate/gregorian.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # This file is part of convertdate.

--- a/convertdate/hebrew.py
+++ b/convertdate/hebrew.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # This file is part of convertdate.

--- a/convertdate/holidays.py
+++ b/convertdate/holidays.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # This file is part of convertdate.

--- a/convertdate/indian_civil.py
+++ b/convertdate/indian_civil.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # This file is part of convertdate.

--- a/convertdate/islamic.py
+++ b/convertdate/islamic.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # This file is part of convertdate.

--- a/convertdate/iso.py
+++ b/convertdate/iso.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # This file is part of convertdate.

--- a/convertdate/julian.py
+++ b/convertdate/julian.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # This file is part of convertdate.

--- a/convertdate/julianday.py
+++ b/convertdate/julianday.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # This file is part of convertdate.

--- a/convertdate/mayan.py
+++ b/convertdate/mayan.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # This file is part of convertdate.

--- a/convertdate/ordinal.py
+++ b/convertdate/ordinal.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # This file is part of convertdate.

--- a/convertdate/persian.py
+++ b/convertdate/persian.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # This file is part of convertdate.

--- a/convertdate/positivist.py
+++ b/convertdate/positivist.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # This file is part of convertdate.

--- a/convertdate/utils.py
+++ b/convertdate/utils.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # This file is part of convertdate.


### PR DESCRIPTION
The shebang is not needed as it's a module and the files should not be executed.

This is also an issue for packagers.

Would be nice if you could make a new release after merging this as for the Fedora Package I'm required to remove them during the build process. Thanks. 