### PR TITLE
Add support for non-Western Easter

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,25 @@ but pull requests are welcome.
 
     # Some Jewish holidays are included
     holidays.rosh_hashanah(2014)
+    
+    # Easter can be calculated according to different churches 
+    # ('western', 'orthodox', 'eastern') and expressed according to 
+    # any supported calendar.
+    # The eastern Christian computation differs from the Orthodox one
+    # 4 times in each 532-year cycle.
+    
+    holidays.easter(2019)
+    # (2019, 4, 21)
+    holidays.easter(2019, calendar="islamic")
+    # (1440, 8, 15)
+    holidays.easter(2019, church="orthodox")
+    # (2019, 4, 28)
+    holidays.easter(2019, church="orthodox", calendar="julian")
+    # (2019, 4, 15)
+    holidays.easter(1824, church="orthodox", calendar="julian")
+    # (1824, 4, 6)
+    holidays.easter(1824, church="eastern", calendar="julian")
+    # (1824, 4, 13)
 
 Utils
 -----

--- a/tests/test_holidays.py
+++ b/tests/test_holidays.py
@@ -72,7 +72,7 @@ class TestHolidays(unittest.TestCase):
         assert holidays.thanksgiving(2015, 'canada') == (2015, 10, 12)
 
     def test_easter(self):
-        easters = [
+        easters = { 'western': [
             (1994, 4, 3),
             (1995, 4, 16),
             (1996, 4, 7),
@@ -114,11 +114,63 @@ class TestHolidays(unittest.TestCase):
             (2032, 3, 28),
             (2033, 4, 17),
             (2034, 4, 9)
-        ]
-        for y, m, d in easters:
+        ],
+        'eastern': [
+            (1999, 4, 11),
+            (2000, 4, 30),
+            (2001, 4, 15),
+            (2002, 5, 5),
+            (2003, 4, 27),
+            (2004, 4, 11),
+            (2005, 5, 1),
+            (2006, 4, 23),
+            (2007, 4, 8),
+            (2008, 4, 27),
+            (2009, 4, 19),
+            (2010, 4, 4),
+            (2011, 4, 24),
+            (2012, 4, 15),
+            (2013, 5, 5),
+            (2014, 4, 20),
+            (2015, 4, 12),
+            (2016, 5, 1),
+            (2017, 4, 16),
+            (2018, 4, 8),
+            (2019, 4, 28),
+            (2020, 4, 19),
+            (2021, 5, 2),
+            (2022, 4, 24),
+            (2023, 4, 16),
+            (2024, 5, 5),
+            (2025, 4, 20),
+            (2026, 4, 12),
+            (2027, 5, 2),
+            (2028, 4, 16),
+            (2029, 4, 8),
+            (2030, 4, 28),
+            (2031, 4, 13),
+            (2032, 5, 2),
+            (2033, 4, 24),
+            (2034, 4, 9),
+            (2035, 4, 29),
+            (2036, 4, 20),
+            (2037, 4, 5),
+            (2038, 4, 25),
+            (2039, 4, 17)
+        ]}
+        for y, m, d in easters.get('western'):
             self.assertEqual(holidays.easter(y), (y, m, d))
+        for y, m, d in easters.get('eastern'):
+            self.assertEqual(holidays.easter(y, church="orthodox", calendar="gregorian"), (y, m, d))
+            self.assertEqual(holidays.easter(y, church="eastern", calendar="gregorian"), (y, m, d))
+
+        # Test some years when Julian Easter falls on April 6
+        for y in (1634, 1729, 1824, 2071, 2166, 2261, 2356):
+            self.assertEqual((y, 4, 6), holidays.easter(y, church="orthodox", calendar="julian"))
+            self.assertEqual((y, 4, 13), holidays.easter(y, church="eastern", calendar="julian"))
 
         self.assertEqual(self.h.easter, (2015, 4, 5))
+        self.assertEqual((1436, 6, 15), holidays.easter(2015, calendar="islamic"))
 
     def test_jewish_holidays(self):
         # http://www.chabad.org/holidays/passover/pesach_cdo/aid/671901/jewish/When-is-Passover-in-2013-2014-2015-2016-and-2017.htm


### PR DESCRIPTION
This pull request includes calculation of Easter for the Orthodox and other eastern churches, and also allows expression of the date of Easter in any of the supported calendars.