### PR TITLE
don't limit upper version of pytz

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
     ],
 
     install_requires=[
-        'pytz>=2014.10, < 2020',
+        'pytz>=2014.10',
         'pymeeus>=0.3.6, <=1'
     ]
 )


### PR DESCRIPTION
pytz 2020.1 came out very recenty.

It will break environments that need the new `pytz` and `convertdate`