### PR TITLE
Add architecture ppc64le to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,11 @@
 # Licensed under the MIT license:
 # http://opensource.org/licenses/MIT
 # Copyright (c) 2016-2020, fitnr <fitnr@fakeisthenewreal>
+os: linux
+arch:
+  - amd64
+  - ppc64le
+
 language: python
 
 python:
@@ -19,6 +24,11 @@ python:
  - pypy3
 
 matrix:
+  exclude:
+  - arch: ppc64le
+    python: 
+      - pypy
+      - pypy3 
   allow_failures:
    - python: 3.4
    - python: pypy3


### PR DESCRIPTION
Thanks for your code.
Add support for architecture ppc64le. Exclude pypy and pypy3 as they are not available for ppc64le.
This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3