### PR TITLE
Fix Ayyám-i-Há

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Dates in this period are returned as month 19, and the month of &lsquo;Al&aacute
 from convertdate import bahai
 # the first day of Ayyam-i-Ha:
 bahai.to_gregorian(175, 19, 1)
-# (2019, 2, 11)
+# (2019, 2, 26)
 # The first day of 'Ala:
 bahai.to_gregorian(175, 20, 1)
 # (2019, 3, 2)

--- a/convertdate/bahai.py
+++ b/convertdate/bahai.py
@@ -58,6 +58,8 @@ def to_jd(year, month, day):
         gy = year - 1 + EPOCH_GREGORIAN_YEAR
         n_month, n_day = gregorian_nawruz(gy)
         return gregorian.to_jd(gy, n_month, n_day - 1) + day + (month - 1) * 19
+    if month == 19:
+        return to_jd(year, month - 1, 19) + day
 
     return to_jd(year, month - 1, day) + month_length(year, month)
 

--- a/convertdate/bahai.py
+++ b/convertdate/bahai.py
@@ -59,9 +59,12 @@ def to_jd(year, month, day):
         n_month, n_day = gregorian_nawruz(gy)
         return gregorian.to_jd(gy, n_month, n_day - 1) + day + (month - 1) * 19
     if month == 19:
+        # Count Ayyám-i-Há from the last day of Mulk
         return to_jd(year, month - 1, 19) + day
-
-    return to_jd(year, month - 1, day) + month_length(year, month)
+    # For the month of ‘Alá we will count _backwards_ from the next Naw Rúz
+    gy = year + EPOCH_GREGORIAN_YEAR
+    n_month, n_day = gregorian_nawruz(gy)
+    return gregorian.to_jd(gy, n_month, n_day) - 20 + day
 
 
 def from_jd(jd):


### PR DESCRIPTION
Fixes #32

The conversion to Gregorian of the Ayyám-i-Há period for the Bahá'í calendar was not quite right.

The solution was to count from the last day of the preceding month for dates within Ayyám-i-Há, and to count _back_ from Naw Rúz for dates after Ayyám-i-Há.

Tests pass and the README is updated to correct this