### PR TITLE
tostring method and gematria

### DIFF
--- a/src/convertdate/armenian.py
+++ b/src/convertdate/armenian.py
@@ -166,9 +166,9 @@ def monthcalendar(year, month, method=None):
     monthlen = month_length(year, month, method)
     return monthcalendarhelper(start_weekday, monthlen)
 
-
-def tostring(year, month, day, lang=None):
+def format(year, month, day, lang=None):
     """Convert an Armenian date into a string with the format DD MONTH YYYY."""
+    # pylint: disable=redefined-builtin
     lang = lang or "en"
     if lang[0:2] == 'hy' or lang[0:2] == 'am' or lang == 'arm':
         month_name = MONTHS_ARM[month - 1]
@@ -176,3 +176,7 @@ def tostring(year, month, day, lang=None):
         month = month_name = MONTHS[month - 1]
 
     return "{0:d} {1:} {2:d}".format(day, month_name, year)
+
+def tostring(year, month, day, lang=None):
+    """Kept for backwards compatibility, the format function name will be standard across the library"""
+    return format(year, month, day, lang)

--- a/src/convertdate/bahai.py
+++ b/src/convertdate/bahai.py
@@ -204,8 +204,9 @@ def monthcalendar(year, month):
     monthlen = month_length(year, month)
     return monthcalendarhelper(start_weekday, monthlen)
 
-def tostring(year, month, day, lang=None):
+def format(year, month, day, lang=None):
     """Convert a Baha'i date into a string with the format DD MONTH YYYY."""
+    # pylint: disable=redefined-builtin
     lang = lang or "en"
     if lang[0:2] == 'ar' or lang[0:2] == 'fa':
         month_name = MONTHS[month - 1]

--- a/src/convertdate/bahai.py
+++ b/src/convertdate/bahai.py
@@ -203,3 +203,13 @@ def monthcalendar(year, month):
     start_weekday = jwday(to_jd(year, month, 1))
     monthlen = month_length(year, month)
     return monthcalendarhelper(start_weekday, monthlen)
+
+def tostring(year, month, day, lang=None):
+    """Convert a Baha'i date into a string with the format DD MONTH YYYY."""
+    lang = lang or "en"
+    if lang[0:2] == 'ar' or lang[0:2] == 'fa':
+        month_name = MONTHS[month - 1]
+    else:
+        month_name = ENGLISH_MONTHS[month - 1]
+
+    return "{0:d} {1:} {2:d}".format(day, month_name, year)

--- a/src/convertdate/coptic.py
+++ b/src/convertdate/coptic.py
@@ -82,3 +82,7 @@ def monthcalendar(year, month):
     start_weekday = jwday(to_jd(year, month, 1))
     monthlen = month_length(year, month)
     return monthcalendarhelper(start_weekday, monthlen)
+
+def tostring(year, month, day):
+    """Convert a Coptic date into a string with the format DD MONTH YYYY."""
+    return "{0:d} {1:} {2:d}".format(day, MONTHS[month-1], year)

--- a/src/convertdate/coptic.py
+++ b/src/convertdate/coptic.py
@@ -83,6 +83,7 @@ def monthcalendar(year, month):
     monthlen = month_length(year, month)
     return monthcalendarhelper(start_weekday, monthlen)
 
-def tostring(year, month, day):
+def format(year, month, day):
     """Convert a Coptic date into a string with the format DD MONTH YYYY."""
+    # pylint: disable=redefined-builtin
     return "{0:d} {1:} {2:d}".format(day, MONTHS[month-1], year)

--- a/src/convertdate/french_republican.py
+++ b/src/convertdate/french_republican.py
@@ -371,3 +371,7 @@ def to_gregorian(an, mois, jour, method=None):
 def format(an, mois, jour):
     # pylint: disable=redefined-builtin
     return "{0} {1} {2}".format(jour, MOIS[mois - 1], an)
+
+def tostring(an, mois, jour):
+    """Convert a FR date into a string with the format DD MONTH YYYY."""
+    return "{0} {1} {2}".format(jour, MOIS[mois - 1], an)

--- a/src/convertdate/french_republican.py
+++ b/src/convertdate/french_republican.py
@@ -369,9 +369,6 @@ def to_gregorian(an, mois, jour, method=None):
 
 
 def format(an, mois, jour):
-    # pylint: disable=redefined-builtin
-    return "{0} {1} {2}".format(jour, MOIS[mois - 1], an)
-
-def tostring(an, mois, jour):
     """Convert a FR date into a string with the format DD MONTH YYYY."""
+    # pylint: disable=redefined-builtin
     return "{0} {1} {2}".format(jour, MOIS[mois - 1], an)

--- a/src/convertdate/gregorian.py
+++ b/src/convertdate/gregorian.py
@@ -5,6 +5,7 @@
 # http://opensource.org/licenses/MIT
 # Copyright (c) 2016, fitnr <fitnr@fakeisthenewreal>
 from calendar import isleap, monthrange
+from datetime import date
 
 from .utils import floor, jwday, monthcalendarhelper
 
@@ -123,3 +124,8 @@ def monthcalendar(year, month):
     monthlen = month_length(year, month)
 
     return monthcalendarhelper(start_weekday, monthlen)
+
+def format(year, month, day, format_string="%d %B %Y"):
+    # pylint: disable=redefined-builtin
+    d = date(year,month,day)
+    return d.strftime(format_string)

--- a/src/convertdate/hebrew.py
+++ b/src/convertdate/hebrew.py
@@ -9,8 +9,6 @@ from math import trunc
 from . import gregorian
 from .utils import jwday, monthcalendarhelper
 
-from hebrew_numbers import int_to_gematria
-
 EPOCH = 347995.5
 HEBREW_YEAR_OFFSET = 3760
 

--- a/src/convertdate/hebrew.py
+++ b/src/convertdate/hebrew.py
@@ -9,6 +9,8 @@ from math import trunc
 from . import gregorian
 from .utils import jwday, monthcalendarhelper
 
+from hebrew_numbers import int_to_gematria
+
 EPOCH = 347995.5
 HEBREW_YEAR_OFFSET = 3760
 
@@ -26,6 +28,38 @@ TEVETH = 10
 SHEVAT = 11
 ADAR = 12
 VEADAR = 13
+
+MONTHS = {
+        7: 'TISHRI',
+        8: 'HESHVAN',
+        9: 'KISLEV',
+        10: 'TEVETH',
+        11: 'SHEVAT',
+        12: 'ADAR',
+        13: 'ADAR BET',
+        1: 'NISAN',
+        2: 'IYYAR',
+        3: 'SIVAN',
+        4: 'TAMMUZ',
+        5: 'AV',
+        6: 'ELUL'
+}
+
+MONTHS_HEB = {
+        7: u'תשרי',
+        8: u'חשוון',
+        9: u'כסלו',
+        10: u'טבת',
+        11: u'שבט',
+        12: u'אדר',
+        13: u'אדר ב',
+        1: u'ניסן',
+        2: u'אייר',
+        3: u'סיוון',
+        4: u'תמוז',
+        5: u'אב',
+        6: u'אלול'
+}
 
 
 def leap(year):
@@ -170,3 +204,17 @@ def monthcalendar(year, month):
     start_weekday = jwday(to_jd(year, month, 1))
     monthlen = month_days(year, month)
     return monthcalendarhelper(start_weekday, monthlen)
+
+def tostring(year, month, day, lang=None):
+    """Convert a Hebrew date into a string with the format DD MONTH YYYY."""
+    lang = lang or "en"
+    if lang[0:2] == "he" :
+        str_year = ''
+        if year > 999:
+            large_part = (year//1000)*1000
+            year = year-large_part
+            str_year += int_to_gematria(large_part//1000)
+        str_year += int_to_gematria(year)
+        return f"{int_to_gematria(day)} {MONTHS_HEB.get(month)} {str_year}"
+    else:
+        return f"{day} {MONTHS.get(month)} {year}"

--- a/src/convertdate/hebrew.py
+++ b/src/convertdate/hebrew.py
@@ -207,14 +207,27 @@ def monthcalendar(year, month):
 
 def tostring(year, month, day, lang=None):
     """Convert a Hebrew date into a string with the format DD MONTH YYYY."""
+    if year < 1:
+        return "Not a valid year"
     lang = lang or "en"
     if lang[0:2] == "he" :
+        # the hebrew gematria is a string of letters that represent a number
+        # it is the traditional way to write down a date in this calendar
+        # for year numbers greater than 1000, the gematria must be split 
+        # into a millenia part, and a year part
         str_year = ''
         if year > 999:
-            large_part = (year//1000)*1000
-            year = year-large_part
-            str_year += int_to_gematria(large_part//1000)
-        str_year += int_to_gematria(year)
+            millenia = year//1000
+            year = year - (millenia*1000)
+            if year > 0:
+                str_year += int_to_gematria(millenia)
+            else: #special representation for multiples of 1000
+                if millenia > 1:
+                    str_year += int_to_gematria(millenia-1)
+        if year > 0:
+            str_year += int_to_gematria(year)
+        else: #special representation for multiples of 1000
+            str_year += u"תת״ר"
         return f"{int_to_gematria(day)} {MONTHS_HEB.get(month)} {str_year}"
     else:
         return f"{day} {MONTHS.get(month)} {year}"

--- a/src/convertdate/hebrew.py
+++ b/src/convertdate/hebrew.py
@@ -29,37 +29,37 @@ SHEVAT = 11
 ADAR = 12
 VEADAR = 13
 
-MONTHS = {
-        7: 'TISHRI',
-        8: 'HESHVAN',
-        9: 'KISLEV',
-        10: 'TEVETH',
-        11: 'SHEVAT',
-        12: 'ADAR',
-        13: 'ADAR BET',
-        1: 'NISAN',
-        2: 'IYYAR',
-        3: 'SIVAN',
-        4: 'TAMMUZ',
-        5: 'AV',
-        6: 'ELUL'
-}
+MONTHS = [
+    'NISAN',
+    'IYYAR',
+    'SIVAN',
+    'TAMMUZ',
+    'AV',
+    'ELUL',
+    'TISHRI',
+    'HESHVAN',
+    'KISLEV',
+    'TEVETH',
+    'SHEVAT',
+    'ADAR',
+    'ADAR BET'
+]
 
-MONTHS_HEB = {
-        7: u'תשרי',
-        8: u'חשוון',
-        9: u'כסלו',
-        10: u'טבת',
-        11: u'שבט',
-        12: u'אדר',
-        13: u'אדר ב',
-        1: u'ניסן',
-        2: u'אייר',
-        3: u'סיוון',
-        4: u'תמוז',
-        5: u'אב',
-        6: u'אלול'
-}
+MONTHS_HEB = [
+    u'ניסן',
+    u'אייר',
+    u'סיוון',
+    u'תמוז',
+    u'אב',
+    u'אלול',
+    u'תשרי',
+    u'חשוון',
+    u'כסלו',
+    u'טבת',
+    u'שבט',
+    u'אדר',
+    u'אדר ב'
+]
 
 
 def leap(year):
@@ -205,29 +205,12 @@ def monthcalendar(year, month):
     monthlen = month_days(year, month)
     return monthcalendarhelper(start_weekday, monthlen)
 
-def tostring(year, month, day, lang=None):
+def format(year, month, day, lang=None):
     """Convert a Hebrew date into a string with the format DD MONTH YYYY."""
-    if year < 1:
-        return "Not a valid year"
+    # pylint: disable=redefined-builtin
     lang = lang or "en"
     if lang[0:2] == "he" :
-        # the hebrew gematria is a string of letters that represent a number
-        # it is the traditional way to write down a date in this calendar
-        # for year numbers greater than 1000, the gematria must be split 
-        # into a millenia part, and a year part
-        str_year = ''
-        if year > 999:
-            millenia = year//1000
-            year = year - (millenia*1000)
-            if year > 0:
-                str_year += int_to_gematria(millenia)
-            else: #special representation for multiples of 1000
-                if millenia > 1:
-                    str_year += int_to_gematria(millenia-1)
-        if year > 0:
-            str_year += int_to_gematria(year)
-        else: #special representation for multiples of 1000
-            str_year += u"תת״ר"
-        return f"{int_to_gematria(day)} {MONTHS_HEB.get(month)} {str_year}"
+        month_name = MONTHS_HEB[month-1]
     else:
-        return f"{day} {MONTHS.get(month)} {year}"
+        month_name = MONTHS[month-1]
+    return f"{day} {month_name} {year}"

--- a/src/convertdate/indian_civil.py
+++ b/src/convertdate/indian_civil.py
@@ -138,3 +138,7 @@ def monthcalendar(year, month):
     start_weekday = jwday(to_jd(year, month, 1))
     monthlen = month_length(year, month)
     return monthcalendarhelper(start_weekday, monthlen)
+
+def tostring(year, month, day):
+    """Convert a Indian Civil date into a string with the format DD MONTH YYYY."""
+    return "{0:d} {1:} {2:d}".format(day, MONTHS[month-1], year)

--- a/src/convertdate/indian_civil.py
+++ b/src/convertdate/indian_civil.py
@@ -139,6 +139,7 @@ def monthcalendar(year, month):
     monthlen = month_length(year, month)
     return monthcalendarhelper(start_weekday, monthlen)
 
-def tostring(year, month, day):
+def format(year, month, day):
     """Convert a Indian Civil date into a string with the format DD MONTH YYYY."""
+    # pylint: disable=redefined-builtin
     return "{0:d} {1:} {2:d}".format(day, MONTHS[month-1], year)

--- a/src/convertdate/islamic.py
+++ b/src/convertdate/islamic.py
@@ -82,6 +82,7 @@ def monthcalendar(year, month):
     monthlen = month_length(year, month)
     return monthcalendarhelper(start_weekday, monthlen)
 
-def tostring(year, month, day):
+def format(year, month, day):
     """Convert an Islamic date into a string with the format DD MONTH YYYY."""
+    # pylint: disable=redefined-builtin
     return "{0:d} {1:} {2:d}".format(day, MONTHS[month-1], year)

--- a/src/convertdate/islamic.py
+++ b/src/convertdate/islamic.py
@@ -81,3 +81,7 @@ def monthcalendar(year, month):
     start_weekday = jwday(to_jd(year, month, 1))
     monthlen = month_length(year, month)
     return monthcalendarhelper(start_weekday, monthlen)
+
+def tostring(year, month, day):
+    """Convert an Islamic date into a string with the format DD MONTH YYYY."""
+    return "{0:d} {1:} {2:d}".format(day, MONTHS[month-1], year)

--- a/src/convertdate/persian.py
+++ b/src/convertdate/persian.py
@@ -12,6 +12,21 @@ from .utils import ceil, jwday, monthcalendarhelper
 EPOCH = 1948320.5
 WEEKDAYS = ("Doshanbeh", "Seshhanbeh", "Chaharshanbeh", "Panjshanbeh", "Jomeh", "Shanbeh", "Yekshanbeh")
 
+MONTHS = [
+    "Farvardin",
+    "Ordibehesht",
+    "Khordad",
+    "Tir",
+    "Mordad",
+    "Shahrivar",
+    "Mehr",
+    "Aban",
+    "Azar",
+    "Dey",
+    "Bahman",
+    "Esfand"
+]
+
 HAS_31_DAYS = (1, 2, 3, 4, 5, 6)
 HAS_30_DAYS = (7, 8, 9, 10, 11)
 
@@ -104,3 +119,7 @@ def monthcalendar(year, month):
     start_weekday = jwday(to_jd(year, month, 1))
     monthlen = month_length(year, month)
     return monthcalendarhelper(start_weekday, monthlen)
+
+def tostring(year, month, day):
+    """Convert a Persian date into a string with the format DD MONTH YYYY."""
+    return "{0:d} {1:} {2:d}".format(day, MONTHS[month-1], year)

--- a/src/convertdate/persian.py
+++ b/src/convertdate/persian.py
@@ -120,6 +120,7 @@ def monthcalendar(year, month):
     monthlen = month_length(year, month)
     return monthcalendarhelper(start_weekday, monthlen)
 
-def tostring(year, month, day):
+def format(year, month, day):
     """Convert a Persian date into a string with the format DD MONTH YYYY."""
+    # pylint: disable=redefined-builtin
     return "{0:d} {1:} {2:d}".format(day, MONTHS[month-1], year)


### PR DESCRIPTION
Hello,
I have used convertdate in a Reddit bot to help translators convert between different calendars.
I've noticed in the Armenian calendar that you have a tostring method that is missing from other calendars, and which would be helpful to me. 
So I've created this branch and PR in order to include the tostring method to other calendars.
In the hebrew calendar, the method includes a number-to-gematria conversion. If this seems off-topic to you, I can revert it and keep the numbers as-is.
I have included the months of the Persian calendar, [as per Wikipedia](https://en.wikipedia.org/wiki/Solar_Hijri_calendar#Month_names).
Thank you.