### PR TITLE
Avoid broken pymeeus release 0.3.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
     python_requires=">=3.5",
     install_requires=[
         'pytz>=2014.10',
-        'pymeeus>=0.3.6, <=1'
+        'pymeeus>=0.3.6, <=1, !=0.3.8'
     ],
     tests_require=tests_require,
     extras_require={


### PR DESCRIPTION
[`pymeeus`](https://github.com/architest/pymeeus) released version [`0.3.8`](https://pypi.org/project/PyMeeus/0.3.8/) today, which has [a bug](https://github.com/architest/pymeeus/issues/4) which prevents it from being pip-installable (which, in turn, is preventing any packages depending on it, such as this one, to fail pip-installation).  This PR ensures `convertdate` will not try to install `pymeeus==0.3.8` as a dependency to allow it to continue to be pip-installable in the interim until if/when a new, working release of `pymeeus` is published.