### PR TITLE
Use timezone.utc instead of pytz.utc

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,6 @@ setup(
     ],
     python_requires=">=3.5",
     install_requires=[
-        'pytz>=2014.10',
         'pymeeus>=0.3.13, <=1'
     ],
     tests_require=tests_require,

--- a/src/convertdate/julianday.py
+++ b/src/convertdate/julianday.py
@@ -8,9 +8,7 @@
 The `Julian day <https://en.wikipedia.org/wiki/Julian_day>`__
 is a continuous count of days since the beginning of the Julian era on January 1, 4713 BC.
 """
-from datetime import datetime
-
-from pytz import utc
+from datetime import datetime, timezone
 
 from . import gregorian, julian
 
@@ -36,7 +34,16 @@ def to_datetime(jdc):
     # down to ms, which are 1/1000 of a second
     ms = int(1000 * round(msfrac, 6))
 
-    return datetime(year, month, day, int(hours), int(mins), int(secs), int(ms), tzinfo=utc)
+    return datetime(
+        year,
+        month,
+        day,
+        int(hours),
+        int(mins),
+        int(secs),
+        int(ms),
+        tzinfo=timezone.utc
+    )
 
 
 def from_datetime(dt):

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 import time
-from datetime import datetime
-
-import pytz
+from datetime import datetime, timezone
 
 from convertdate import coptic, dublin, gregorian, hebrew, islamic, iso, julian, julianday, ordinal, persian, utils
 
@@ -115,16 +113,16 @@ class TestConvertdate(CalTestCase):
 
     def test_julian_day(self):
         self.assertEqual(julianday.from_gregorian(*self.c_greg), self.c)
-        self.assertEqual(julianday.to_datetime(self.c), datetime(1492, 10, 21, tzinfo=pytz.utc))
-        self.assertEqual(julianday.to_datetime(self.x), datetime(2016, 2, 29, tzinfo=pytz.utc))
+        self.assertEqual(julianday.to_datetime(self.c), datetime(1492, 10, 21, tzinfo=timezone.utc))
+        self.assertEqual(julianday.to_datetime(self.x), datetime(2016, 2, 29, tzinfo=timezone.utc))
 
-        self.assertEqual(julianday.to_datetime(self.c + 0.25), datetime(1492, 10, 21, 6, tzinfo=pytz.utc))
-        self.assertEqual(julianday.to_datetime(self.x + 0.525), datetime(2016, 2, 29, 12, 36, tzinfo=pytz.utc))
+        self.assertEqual(julianday.to_datetime(self.c + 0.25), datetime(1492, 10, 21, 6, tzinfo=timezone.utc))
+        self.assertEqual(julianday.to_datetime(self.x + 0.525), datetime(2016, 2, 29, 12, 36, tzinfo=timezone.utc))
 
-        dt = datetime(2014, 11, 8, 3, 37, tzinfo=pytz.utc)
+        dt = datetime(2014, 11, 8, 3, 37, tzinfo=timezone.utc)
         self.assertEqual(julianday.from_datetime(dt), 2456969.65069)
 
-        self.assertEqual(julianday.to_datetime(self.x + 0.525), datetime(2016, 2, 29, 12, 36, tzinfo=pytz.utc))
+        self.assertEqual(julianday.to_datetime(self.x + 0.525), datetime(2016, 2, 29, 12, 36, tzinfo=timezone.utc))
 
     def test_month_length_julian(self):
         self.assertEqual(julian.month_length(1582, 10), 31)

--- a/tests/test_julian.py
+++ b/tests/test_julian.py
@@ -1,5 +1,4 @@
 from convertdate import julian
-import pytz
 
 from . import CalTestCase
 


### PR DESCRIPTION
Both [pytz.utc](https://github.com/stub42/pytz/blob/2ed682a7c4079042f50975970fc4f503c8450058/src/pytz/__init__.py#L221-L222) and [timezone.utc](https://docs.python.org/3.5/library/datetime.html#datetime.timezone.utc) should equal to an offset/dst of 0, as far as tzinfo structure is concerned, so there is no need to require pytz just to express utc timezone (as far as I'm aware).

Note: tox fialed locally only for 3.9, seemingly because it didn't install pymeeus , not sure if this is expected or not.