### PR TITLE
Add badges to readme for python versions etc

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,16 @@ Schwartz. It has been significantly updated and expanded.
 
 [Consult the complete docs for detailed usage info](https://convertdate.readthedocs.io/).
 
+
+![PyPI](https://img.shields.io/pypi/v/convertdate)
+![PyPI - Python Version](https://img.shields.io/pypi/pyversions/convertdate)
+![PyPI - License](https://img.shields.io/pypi/l/convertdate)
+![PyPI - Downloads](https://img.shields.io/pypi/dd/convertdate)
+![Libraries.io dependency status for latest release](https://img.shields.io/librariesio/release/pypi/convertdate)
+[![convertdate](https://github.com/fitnr/convertdate/actions/workflows/python.yml/badge.svg)](https://github.com/fitnr/convertdate/actions/workflows/python.yml)
+
+--- 
+
 Available calendars:
 
 -   Armenian


### PR DESCRIPTION
Thought you might want to add some badges to the readme.

Among other things, this is an easy way to make explicit the supported versions of python. (i.e., not python 2, as in #29 )

If you rename your `convertdate` github actions workflow to `build` or `unit tests` or something like that and update the badge, the label would be more meaningful.