### PR TITLE
Fix `mayan` to be included twice in `__all__`

### DIFF
--- a/src/convertdate/__init__.py
+++ b/src/convertdate/__init__.py
@@ -58,7 +58,6 @@ __all__ = [
     'mayan',
     'persian',
     'positivist',
-    'mayan',
     'ordinal',
     'utils',
 ]


### PR DESCRIPTION
Second one is here: https://github.com/fitnr/convertdate/blob/5c955e87c2972f574901baa6ffe34e32b6a7ab28/src/convertdate/__init__.py#L58